### PR TITLE
Allow and test new dependency versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,7 @@ jobs:
           - { php-version: '8.1', doctrine-bundle-version: '^3.0' }
           - { php-version: '8.2', doctrine-bundle-version: '^3.0' }
           - { php-version: '8.3', doctrine-bundle-version: '^3.0' }
+          - { symfony-version: '^5.2', doctrine-bundle-version: '^3.0' }
     name: >-
       ${{ matrix.php-version }} with
       sf ${{ matrix.symfony-version }},

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,8 @@ jobs:
           - { php-version: '8.1', doctrine-bundle-version: '^3.0' }
           - { php-version: '8.2', doctrine-bundle-version: '^3.0' }
           - { php-version: '8.3', doctrine-bundle-version: '^3.0' }
+          - { doctrine-bundle-version: '^3.0', doctrine-dbal-version: '^2.12' }
+          - { doctrine-bundle-version: '^3.0', doctrine-dbal-version: '^3.0' }
           - { symfony-version: '^5.2', doctrine-bundle-version: '^3.0' }
     name: >-
       ${{ matrix.php-version }} with

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,7 @@ jobs:
         doctrine-bundle-version: ['^2.2']
         doctrine-migrations-bundle-version: ['^3.0']
         exclude:
+          - { php-version: '8.0', symfony-version: '^6.0' }
           - { php-version: '8.0', symfony-version: '^7.0' }
           - { php-version: '8.1', symfony-version: '^7.0' }
           - { php-version: '8.0', doctrine-dbal-version: '^4.0' }

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,20 +10,25 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-version: ['8.0', '8.1', '8.2', '8.3', '8.4']
-        symfony-version: ['^5.2', '^6.0', '^7.0']
+        php-version: ['8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+        symfony-version: ['^5.2', '^6.0', '^7.0', '^8.0']
         doctrine-dbal-version: ['^2.12', '^3.0', '^4.0']
-        doctrine-bundle-version: ['^2.2']
-        doctrine-migrations-bundle-version: ['^3.0']
+        doctrine-bundle-version: ['^2.2', '^3.0']
+        doctrine-migrations-bundle-version: ['^3.0', '^4.0']
         exclude:
-          - php-version: '8.0'
-            symfony-version: '^7.0'
-          - php-version: '8.1'
-            symfony-version: '^7.0'
-          - php-version: '8.0'
-            doctrine-dbal-version: '^4.0'
-          - symfony-version: '^7.0'
-            doctrine-dbal-version: '^2.12'
+          - { php-version: '8.0', symfony-version: '^7.0' }
+          - { php-version: '8.1', symfony-version: '^7.0' }
+          - { php-version: '8.0', symfony-version: '^8.0' }
+          - { php-version: '8.1', symfony-version: '^8.0' }
+          - { php-version: '8.2', symfony-version: '^8.0' }
+          - { php-version: '8.3', symfony-version: '^8.0' }
+          - { php-version: '8.0', doctrine-migrations-bundle-version: '^4.0' }
+          - { php-version: '8.0', doctrine-dbal-version: '^4.0' }
+          - { symfony-version: '^7.0', doctrine-dbal-version: '^2.12' }
+          - { php-version: '8.0', doctrine-bundle-version: '^3.0' }
+          - { php-version: '8.1', doctrine-bundle-version: '^3.0' }
+          - { php-version: '8.2', doctrine-bundle-version: '^3.0' }
+          - { php-version: '8.3', doctrine-bundle-version: '^3.0' }
     name: >-
       ${{ matrix.php-version }} with
       sf ${{ matrix.symfony-version }},

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,7 @@ jobs:
           - { php-version: '8.3', doctrine-bundle-version: '^3.0' }
           - { doctrine-bundle-version: '^3.0', doctrine-dbal-version: '^2.12' }
           - { doctrine-bundle-version: '^3.0', doctrine-dbal-version: '^3.0' }
+          - { doctrine-bundle-version: '^3.0', symfony-version: '^8.0' }
           - { symfony-version: '^5.2', doctrine-bundle-version: '^3.0' }
     name: >-
       ${{ matrix.php-version }} with

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,9 @@ jobs:
           - { php-version: '8.2', symfony-version: '^8.0' }
           - { php-version: '8.3', symfony-version: '^8.0' }
           - { php-version: '8.0', doctrine-migrations-bundle-version: '^4.0' }
+          - { php-version: '8.1', doctrine-migrations-bundle-version: '^4.0' }
+          - { php-version: '8.2', doctrine-migrations-bundle-version: '^4.0' }
+          - { php-version: '8.3', doctrine-migrations-bundle-version: '^4.0' }
           - { php-version: '8.0', doctrine-dbal-version: '^4.0' }
           - { symfony-version: '^7.0', doctrine-dbal-version: '^2.12' }
           - { php-version: '8.0', doctrine-bundle-version: '^3.0' }

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
           - { php-version: '8.3', doctrine-bundle-version: '^3.0' }
           - { doctrine-bundle-version: '^3.0', doctrine-dbal-version: '^2.12' }
           - { doctrine-bundle-version: '^3.0', doctrine-dbal-version: '^3.0' }
-          - { doctrine-bundle-version: '^3.0', symfony-version: '^8.0' }
+          - { doctrine-bundle-version: '^2.2', symfony-version: '^8.0' }
           - { symfony-version: '^5.2', doctrine-bundle-version: '^3.0' }
     name: >-
       ${{ matrix.php-version }} with

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,35 +11,15 @@ jobs:
       matrix:
         operating-system: [ubuntu-latest]
         php-version: ['8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
-        symfony-version: ['^5.2', '^6.0', '^7.0', '^8.0']
+        symfony-version: ['^5.2', '^6.0', '^7.0']
         doctrine-dbal-version: ['^2.12', '^3.0', '^4.0']
-        doctrine-bundle-version: ['^2.2', '^3.0']
-        doctrine-migrations-bundle-version: ['^3.0', '^4.0']
+        doctrine-bundle-version: ['^2.2']
+        doctrine-migrations-bundle-version: ['^3.0']
         exclude:
-          - { php-version: '8.0', symfony-version: '^6.0' }
           - { php-version: '8.0', symfony-version: '^7.0' }
           - { php-version: '8.1', symfony-version: '^7.0' }
-          - { php-version: '8.0', symfony-version: '^8.0' }
-          - { php-version: '8.1', symfony-version: '^8.0' }
-          - { php-version: '8.2', symfony-version: '^8.0' }
-          - { php-version: '8.3', symfony-version: '^8.0' }
-          - { php-version: '8.0', doctrine-migrations-bundle-version: '^4.0' }
-          - { php-version: '8.1', doctrine-migrations-bundle-version: '^4.0' }
-          - { php-version: '8.2', doctrine-migrations-bundle-version: '^4.0' }
-          - { php-version: '8.3', doctrine-migrations-bundle-version: '^4.0' }
-          - { doctrine-migrations-bundle-version: '^4.0', doctrine-dbal-version: '^2.12' }
-          - { doctrine-migrations-bundle-version: '^4.0', doctrine-dbal-version: '^3.0' }
-          - { doctrine-migrations-bundle-version: '^4.0', doctrine-bundle-version: '^2.2' }
           - { php-version: '8.0', doctrine-dbal-version: '^4.0' }
           - { symfony-version: '^7.0', doctrine-dbal-version: '^2.12' }
-          - { php-version: '8.0', doctrine-bundle-version: '^3.0' }
-          - { php-version: '8.1', doctrine-bundle-version: '^3.0' }
-          - { php-version: '8.2', doctrine-bundle-version: '^3.0' }
-          - { php-version: '8.3', doctrine-bundle-version: '^3.0' }
-          - { doctrine-bundle-version: '^3.0', doctrine-dbal-version: '^2.12' }
-          - { doctrine-bundle-version: '^3.0', doctrine-dbal-version: '^3.0' }
-          - { doctrine-bundle-version: '^3.0', symfony-version: '^8.0' }
-          - { symfony-version: '^5.2', doctrine-bundle-version: '^3.0' }
     name: >-
       ${{ matrix.php-version }} with
       sf ${{ matrix.symfony-version }},

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,9 @@ jobs:
           - { php-version: '8.1', doctrine-migrations-bundle-version: '^4.0' }
           - { php-version: '8.2', doctrine-migrations-bundle-version: '^4.0' }
           - { php-version: '8.3', doctrine-migrations-bundle-version: '^4.0' }
+          - { doctrine-migrations-bundle-version: '^4.0', doctrine-dbal-version: '^2.12' }
+          - { doctrine-migrations-bundle-version: '^4.0', doctrine-dbal-version: '^3.0' }
+          - { doctrine-migrations-bundle-version: '^4.0', doctrine-bundle-version: '^2.2' }
           - { php-version: '8.0', doctrine-dbal-version: '^4.0' }
           - { symfony-version: '^7.0', doctrine-dbal-version: '^2.12' }
           - { php-version: '8.0', doctrine-bundle-version: '^3.0' }

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,16 +11,35 @@ jobs:
       matrix:
         operating-system: [ubuntu-latest]
         php-version: ['8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
-        symfony-version: ['^5.2', '^6.0', '^7.0']
+        symfony-version: ['^5.2', '^6.0', '^7.0', '^8.0']
         doctrine-dbal-version: ['^2.12', '^3.0', '^4.0']
-        doctrine-bundle-version: ['^2.2']
-        doctrine-migrations-bundle-version: ['^3.0']
+        doctrine-bundle-version: ['^2.2', '^3.0']
+        doctrine-migrations-bundle-version: ['^3.0', '^4.0']
         exclude:
           - { php-version: '8.0', symfony-version: '^6.0' }
           - { php-version: '8.0', symfony-version: '^7.0' }
           - { php-version: '8.1', symfony-version: '^7.0' }
+          - { php-version: '8.0', symfony-version: '^8.0' }
+          - { php-version: '8.1', symfony-version: '^8.0' }
+          - { php-version: '8.2', symfony-version: '^8.0' }
+          - { php-version: '8.3', symfony-version: '^8.0' }
+          - { php-version: '8.0', doctrine-migrations-bundle-version: '^4.0' }
+          - { php-version: '8.1', doctrine-migrations-bundle-version: '^4.0' }
+          - { php-version: '8.2', doctrine-migrations-bundle-version: '^4.0' }
+          - { php-version: '8.3', doctrine-migrations-bundle-version: '^4.0' }
+          - { doctrine-migrations-bundle-version: '^4.0', doctrine-dbal-version: '^2.12' }
+          - { doctrine-migrations-bundle-version: '^4.0', doctrine-dbal-version: '^3.0' }
+          - { doctrine-migrations-bundle-version: '^4.0', doctrine-bundle-version: '^2.2' }
           - { php-version: '8.0', doctrine-dbal-version: '^4.0' }
           - { symfony-version: '^7.0', doctrine-dbal-version: '^2.12' }
+          - { php-version: '8.0', doctrine-bundle-version: '^3.0' }
+          - { php-version: '8.1', doctrine-bundle-version: '^3.0' }
+          - { php-version: '8.2', doctrine-bundle-version: '^3.0' }
+          - { php-version: '8.3', doctrine-bundle-version: '^3.0' }
+          - { doctrine-bundle-version: '^3.0', doctrine-dbal-version: '^2.12' }
+          - { doctrine-bundle-version: '^3.0', doctrine-dbal-version: '^3.0' }
+          - { doctrine-bundle-version: '^3.0', symfony-version: '^8.0' }
+          - { symfony-version: '^5.2', doctrine-bundle-version: '^3.0' }
     name: >-
       ${{ matrix.php-version }} with
       sf ${{ matrix.symfony-version }},

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,7 @@ jobs:
         doctrine-bundle-version: ['^2.2', '^3.0']
         doctrine-migrations-bundle-version: ['^3.0', '^4.0']
         exclude:
+          - { php-version: '8.0', symfony-version: '^6.0' }
           - { php-version: '8.0', symfony-version: '^7.0' }
           - { php-version: '8.1', symfony-version: '^7.0' }
           - { php-version: '8.0', symfony-version: '^8.0' }

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   "require": {
     "php": "^8.0",
     "doctrine/dbal": "^2.12 || ^3.0 || ^4.0",
-    "doctrine/doctrine-bundle": "^2.2 | ^3.0",
+    "doctrine/doctrine-bundle": "^2.2 || ^3.0",
     "doctrine/doctrine-migrations-bundle": "^3.0 || ^4.0",
     "symfony/config": "^5.2 || ^6.0 || ^7.0 || ^8.0",
     "symfony/console": "^5.2 || ^6.0 || ^7.0 || ^8.0",

--- a/composer.json
+++ b/composer.json
@@ -22,19 +22,19 @@
   "require": {
     "php": "^8.0",
     "doctrine/dbal": "^2.12 || ^3.0 || ^4.0",
-    "doctrine/doctrine-bundle": "^2.2 | ^3.0",
-    "doctrine/doctrine-migrations-bundle": "^3.0 || ^4.0",
-    "symfony/config": "^5.2 || ^6.0 || ^7.0 || ^8.0",
-    "symfony/console": "^5.2 || ^6.0 || ^7.0 || ^8.0",
-    "symfony/dependency-injection": "^5.2 || ^6.0 || ^7.0 || ^8.0",
-    "symfony/http-foundation": "^5.2 || ^6.0 || ^7.0 || ^8.0",
-    "symfony/http-kernel": "^5.2 || ^6.0 || ^7.0 || ^8.0"
+    "doctrine/doctrine-bundle": "^2.2",
+    "doctrine/doctrine-migrations-bundle": "^3.0",
+    "symfony/config": "^5.2 || ^6.0 || ^7.0",
+    "symfony/console": "^5.2 || ^6.0 || ^7.0",
+    "symfony/dependency-injection": "^5.2 || ^6.0 || ^7.0",
+    "symfony/http-foundation": "^5.2 || ^6.0 || ^7.0",
+    "symfony/http-kernel": "^5.2 || ^6.0 || ^7.0"
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "3.6.1",
     "phpstan/phpstan": "1.12.23",
     "phpunit/phpunit": "^9.5",
-    "symfony/framework-bundle": "^5.2 || ^6.0 || ^7.0 || ^8.0"
+    "symfony/framework-bundle": "^5.2 || ^6.0 || ^7.0"
   },
   "config": {
     "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,8 @@
     "symfony/http-kernel": "^5.2 || ^6.0 || ^7.0 || ^8.0"
   },
   "require-dev": {
-    "squizlabs/php_codesniffer": "3.6.1",
-    "phpstan/phpstan": "1.12.23",
+    "squizlabs/php_codesniffer": "3.13.5",
+    "phpstan/phpstan": "2.2.2",
     "phpunit/phpunit": "^9.5",
     "symfony/framework-bundle": "^5.2 || ^6.0 || ^7.0 || ^8.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -22,19 +22,19 @@
   "require": {
     "php": "^8.0",
     "doctrine/dbal": "^2.12 || ^3.0 || ^4.0",
-    "doctrine/doctrine-bundle": "^2.2",
-    "doctrine/doctrine-migrations-bundle": "^3.0",
-    "symfony/config": "^5.2 || ^6.0 || ^7.0",
-    "symfony/console": "^5.2 || ^6.0 || ^7.0",
-    "symfony/dependency-injection": "^5.2 || ^6.0 || ^7.0",
-    "symfony/http-foundation": "^5.2 || ^6.0 || ^7.0",
-    "symfony/http-kernel": "^5.2 || ^6.0 || ^7.0"
+    "doctrine/doctrine-bundle": "^2.2 | ^3.0",
+    "doctrine/doctrine-migrations-bundle": "^3.0 || ^4.0",
+    "symfony/config": "^5.2 || ^6.0 || ^7.0 || ^8.0",
+    "symfony/console": "^5.2 || ^6.0 || ^7.0 || ^8.0",
+    "symfony/dependency-injection": "^5.2 || ^6.0 || ^7.0 || ^8.0",
+    "symfony/http-foundation": "^5.2 || ^6.0 || ^7.0 || ^8.0",
+    "symfony/http-kernel": "^5.2 || ^6.0 || ^7.0 || ^8.0"
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "3.6.1",
     "phpstan/phpstan": "1.12.23",
     "phpunit/phpunit": "^9.5",
-    "symfony/framework-bundle": "^5.2 || ^6.0 || ^7.0"
+    "symfony/framework-bundle": "^5.2 || ^6.0 || ^7.0 || ^8.0"
   },
   "config": {
     "allow-plugins": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,6 +9,9 @@ parameters:
       path: src/DependencyInjection/Configuration.php
       count: 1
     -
+      message: '#^Cannot call method [a-zA-Z]+\(\) on mixed\.$#'
+      path: src/DependencyInjection/Configuration.php
+    -
       message: '#^Method [^\s]+ has parameter [^\s]+ with no value type specified in iterable type array\.$#'
       path: src/DependencyInjection/MareinLockDoctrineMigrationsExtension.php
       count: 1
@@ -18,3 +21,6 @@ parameters:
       count: 1
     -
       message: '#^Class Doctrine\\DBAL\\Platforms\\.*Platform not found\.$#'
+    -
+      message: '#^Call to function method_exists\(\) with [^\s]+ and ''getName'' will always evaluate to true\.$#'
+      path: src/Platform/Platforms.php

--- a/src/MareinLockDoctrineMigrationsBundle.php
+++ b/src/MareinLockDoctrineMigrationsBundle.php
@@ -8,5 +8,4 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 final class MareinLockDoctrineMigrationsBundle extends Bundle
 {
-
 }

--- a/src/Platform/PlatformException.php
+++ b/src/Platform/PlatformException.php
@@ -8,5 +8,4 @@ use Exception;
 
 final class PlatformException extends Exception
 {
-
 }


### PR DESCRIPTION
Add PHP 8.5 to test pipeline, and allow `symfony:^8.0`, `doctrine/doctrine-bundle:^3.0`, and `doctrine/doctrine-migrations-bundle:^4.0`.

This becomes a dependency nightmare. Probably time to ditch some old versions after making this work.